### PR TITLE
[feat][fs] Add restoretrash and updatefstrashdays commands

### DIFF
--- a/cli/command/fs/cmd.go
+++ b/cli/command/fs/cmd.go
@@ -47,6 +47,8 @@ func NewFSCommand(dingocli *cli.DingoCli) *cobra.Command {
 		NewFsSummaryCommand(dingocli),
 		NewFsSyncDirStatCommand(dingocli),
 		NewFsUpdateFsEnableDirStatsCommand(dingocli),
+		NewFsUpdateFsTrashDaysCommand(dingocli),
+		NewFsRestoreTrashCommand(dingocli),
 		config.NewFsCommand(dingocli),
 		quota.NewQuotaCommand(dingocli),
 		warmup.NewWarmupCommand(dingocli),

--- a/cli/command/fs/restoretrash.go
+++ b/cli/command/fs/restoretrash.go
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2026 dingofs org, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/dingodb/dingocli/cli/cli"
+	"github.com/dingodb/dingocli/internal/common"
+	"github.com/dingodb/dingocli/internal/errno"
+	"github.com/dingodb/dingocli/internal/output"
+	"github.com/dingodb/dingocli/internal/rpc"
+	"github.com/dingodb/dingocli/internal/utils"
+	"github.com/dingodb/dingocli/proto/dingofs/proto/mds"
+	"github.com/spf13/cobra"
+)
+
+const (
+	FS_RESTORE_TRASH_EXAMPLE = `Examples:
+# tree-rebuild restore of two hour buckets (UTC)
+$ dingo fs restoretrash --fsname dingofs1 --hours 2026-04-05-14,2026-04-05-15
+
+# put every entry back to its live original parent
+$ dingo fs restoretrash --fsname dingofs1 --hours 2026-04-05-14 --putback --restorethreads 10`
+)
+
+type restoreTrashOptions struct {
+	fsid           uint32
+	hours          []string
+	putback        bool
+	restorethreads uint32
+	format         string
+}
+
+// hourResult holds the per-hour restore counters.
+type hourResult struct {
+	Hour     string `json:"hour"`
+	Restored uint64 `json:"restored"`
+	Skipped  uint64 `json:"skipped"`
+	Failed   uint64 `json:"failed"`
+}
+
+func NewFsRestoreTrashCommand(dingocli *cli.DingoCli) *cobra.Command {
+	var options restoreTrashOptions
+
+	cmd := &cobra.Command{
+		Use:     "restoretrash [OPTIONS]",
+		Short:   "restore entries from the trash (requires root)",
+		Args:    utils.NoArgs,
+		Example: FS_RESTORE_TRASH_EXAMPLE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			utils.ReadCommandConfig(cmd)
+			output.SetShow(utils.GetBoolFlag(cmd, utils.VERBOSE))
+
+			fsid, err := rpc.GetFsId(cmd)
+			if err != nil {
+				return err
+			}
+			options.fsid = fsid
+
+			hoursStr := utils.GetStringFlag(cmd, utils.DINGOFS_HOURS)
+			for _, h := range strings.Split(hoursStr, ",") {
+				h = strings.TrimSpace(h)
+				if h != "" {
+					options.hours = append(options.hours, h)
+				}
+			}
+			options.putback = utils.GetBoolFlag(cmd, utils.DINGOFS_PUT_BACK)
+			options.restorethreads = utils.GetUint32Flag(cmd, utils.DINGOFS_RESTORE_THREADS)
+			if options.restorethreads == 0 {
+				options.restorethreads = 1
+			}
+			options.format = utils.GetStringFlag(cmd, utils.FORMAT)
+
+			return runRestoreTrash(cmd, dingocli, options)
+		},
+		SilenceUsage:          false,
+		DisableFlagsInUseLine: true,
+	}
+
+	utils.SetFlagErrorFunc(cmd)
+
+	cmd.Flags().Uint32("fsid", 0, "Filesystem id")
+	cmd.Flags().String("fsname", "", "Filesystem name")
+	utils.AddStringFlag(cmd, utils.DINGOFS_HOURS, "Trash hour buckets to restore (UTC, YYYY-MM-DD-HH), comma-separated")
+	utils.AddBoolFlag(cmd, utils.DINGOFS_PUT_BACK, "Put every entry back to its live original parent (default: tree-rebuild)")
+	utils.AddUint32Flag(cmd, utils.DINGOFS_RESTORE_THREADS, "Number of file restore worker threads")
+
+	utils.AddBoolFlag(cmd, utils.VERBOSE, "Show more debug info")
+	utils.AddConfigFileFlag(cmd)
+	utils.AddFormatFlag(cmd)
+
+	utils.AddDurationFlag(cmd, utils.RPCTIMEOUT, "RPC timeout")
+	utils.AddDurationFlag(cmd, utils.RPCRETRYDElAY, "RPC retry delay")
+	utils.AddUint32Flag(cmd, utils.RPCRETRYTIMES, "RPC retry times")
+
+	utils.AddStringFlag(cmd, utils.DINGOFS_MDSADDR, "Specify mds address")
+
+	return cmd
+}
+
+func runRestoreTrash(cmd *cobra.Command, dingocli *cli.DingoCli, options restoreTrashOptions) error {
+	outputResult := &common.OutputResult{
+		Error: errno.ERR_OK,
+	}
+
+	// only root can restore from trash (server enforces uid == 0)
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("only root can restore files from trash")
+	}
+	if len(options.hours) == 0 {
+		return fmt.Errorf("at least one hour bucket (YYYY-MM-DD-HH, UTC) is required via --hours")
+	}
+
+	// epoch + router
+	epoch, epochErr := rpc.GetFsEpochByFsId(cmd, options.fsid)
+	if epochErr != nil {
+		return epochErr
+	}
+	if routerErr := rpc.InitFsMDSRouter(cmd, options.fsid); routerErr != nil {
+		return routerErr
+	}
+
+	results := make([]hourResult, 0, len(options.hours))
+	for _, hour := range options.hours {
+		res := restoreHour(cmd, options, hour, epoch)
+		results = append(results, res)
+	}
+	outputResult.Result = results
+
+	if options.format == "json" {
+		return output.OutputJson(outputResult)
+	}
+
+	for _, r := range results {
+		fmt.Printf("restore trash %s: restored=%d skipped=%d failed=%d\n", r.Hour, r.Restored, r.Skipped, r.Failed)
+	}
+
+	return nil
+}
+
+// restoreHour restores a single hour bucket, mirroring DoRestoreHour: directories
+// are restored serially in topological order, then files in parallel.
+func restoreHour(cmd *cobra.Command, options restoreTrashOptions, hour string, epoch uint64) hourResult {
+	res := hourResult{Hour: hour}
+
+	// validate hour format; warn and skip rather than abort the whole run
+	if utils.ParseTrashBucketName(hour) == 0 {
+		fmt.Printf("invalid hour format '%s', expected YYYY-MM-DD-HH (UTC), skipped\n", hour)
+		return res
+	}
+
+	// .trash is synthesized client-side, so look up the hour bucket under the
+	// trash root inode directly.
+	bucketInode, err := rpc.Lookup(cmd, options.fsid, common.TRASHINODEID, hour, epoch)
+	if err != nil {
+		fmt.Printf("lookup .trash/%s fail: %s\n", hour, err.Error())
+		return res
+	}
+	bucketIno := bucketInode.GetIno()
+
+	entries, listErr := rpc.ListDentry(cmd, options.fsid, bucketIno, epoch)
+	if listErr != nil {
+		fmt.Printf("list .trash/%s fail: %s\n", hour, listErr.Error())
+		return res
+	}
+	if len(entries) == 0 {
+		return res
+	}
+
+	// partition into directories vs files
+	var dirs, files []*mds.Dentry
+	for _, d := range entries {
+		if d.GetType() == mds.FileType_DIRECTORY {
+			dirs = append(dirs, d)
+		} else {
+			files = append(files, d)
+		}
+	}
+
+	// topologically order dirs so a parent is restored before its children
+	// (a numeric ino sort is not a valid topo order under hash partitioning).
+	dirs = topoOrderTrashDirs(dirs)
+
+	// in tree-rebuild mode, only entries whose original parent was also trashed
+	// (i.e. appears here as a directory) are restored.
+	trashedDirInos := make(map[uint64]struct{})
+	if !options.putback {
+		for _, d := range dirs {
+			trashedDirInos[d.GetIno()] = struct{}{}
+		}
+	}
+
+	var restored, skipped, failed uint64
+
+	// phase 1: restore directories serially
+	for _, d := range dirs {
+		restoreOne(cmd, options, bucketIno, d, trashedDirInos, epoch, &restored, &skipped, &failed)
+	}
+
+	// phase 2: restore files in parallel
+	var wg sync.WaitGroup
+	work := make(chan *mds.Dentry)
+	for i := uint32(0); i < options.restorethreads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for d := range work {
+				restoreOne(cmd, options, bucketIno, d, trashedDirInos, epoch, &restored, &skipped, &failed)
+			}
+		}()
+	}
+	for _, d := range files {
+		work <- d
+	}
+	close(work)
+	wg.Wait()
+
+	res.Restored = atomic.LoadUint64(&restored)
+	res.Skipped = atomic.LoadUint64(&skipped)
+	res.Failed = atomic.LoadUint64(&failed)
+	return res
+}
+
+// topoOrderTrashDirs orders trashed directories so each dir's original parent
+// (parsed from its trash name) is restored before it. Mirrors the Kahn-style
+// ordering in trash_restore.cc.
+func topoOrderTrashDirs(dirs []*mds.Dentry) []*mds.Dentry {
+	pending := make(map[uint64]struct{}, len(dirs))
+	for _, d := range dirs {
+		pending[d.GetIno()] = struct{}{}
+	}
+
+	remaining := append([]*mds.Dentry(nil), dirs...)
+	ordered := make([]*mds.Dentry, 0, len(dirs))
+	progress := true
+	for len(remaining) > 0 && progress {
+		progress = false
+		next := remaining[:0]
+		for _, d := range remaining {
+			origParent := utils.ParseTrashEntryParent(d.GetName())
+			if _, parentPending := pending[origParent]; !parentPending {
+				delete(pending, d.GetIno())
+				ordered = append(ordered, d)
+				progress = true
+			} else {
+				next = append(next, d)
+			}
+		}
+		remaining = next
+	}
+	// leftovers (unparseable names or a cycle): append as-is
+	ordered = append(ordered, remaining...)
+
+	return ordered
+}
+
+// restoreOne restores a single trash entry, updating the counters atomically.
+func restoreOne(cmd *cobra.Command, options restoreTrashOptions, bucketIno uint64, dentry *mds.Dentry,
+	trashedDirInos map[uint64]struct{}, epoch uint64, restored, skipped, failed *uint64) {
+	origParent, _, _, ok := utils.ParseTrashEntryName(dentry.GetName())
+	if !ok || origParent == 0 {
+		fmt.Printf("skip unparseable trash entry '%s'\n", dentry.GetName())
+		atomic.AddUint64(failed, 1)
+		return
+	}
+
+	// tree-rebuild: only restore entries whose original parent was also trashed
+	if !options.putback {
+		if _, isTrashed := trashedDirInos[origParent]; !isTrashed {
+			atomic.AddUint64(skipped, 1)
+			return
+		}
+	}
+
+	allowTrashParent := !options.putback
+
+	// put_back of a directory carries whatever subtree was assembled inside it;
+	// compute the carried totals so the server credits the live ancestor chain.
+	var carriedBytes, carriedInodes uint64
+	if options.putback && dentry.GetType() == mds.FileType_DIRECTORY {
+		b, i, cErr := computeCarried(cmd, options.fsid, dentry.GetIno(), epoch)
+		if cErr != nil {
+			fmt.Printf("compute carried totals for '%s' fail: %s, skip restore\n", dentry.GetName(), cErr.Error())
+			atomic.AddUint64(failed, 1)
+			return
+		}
+		carriedBytes, carriedInodes = b, i
+	}
+
+	err := rpc.RestoreFromTrash(cmd, options.fsid, bucketIno, dentry.GetName(), origParent, allowTrashParent, carriedBytes, carriedInodes, epoch)
+	if err != nil {
+		fmt.Printf("restore '%s' fail: %s\n", dentry.GetName(), err.Error())
+		atomic.AddUint64(failed, 1)
+		return
+	}
+	atomic.AddUint64(restored, 1)
+}
+
+// computeCarried sums the dir-stat totals of a directory subtree, reading each
+// level from its owner MDS. Mirrors ComputeCarried in trash_restore.cc.
+func computeCarried(cmd *cobra.Command, fsId uint32, dirIno uint64, epoch uint64) (bytes uint64, inodes uint64, err error) {
+	pending := []uint64{dirIno}
+	for len(pending) > 0 {
+		dir := pending[len(pending)-1]
+		pending = pending[:len(pending)-1]
+
+		dirStat, statErr := rpc.GetDirStat(cmd, fsId, dir, epoch)
+		if statErr != nil {
+			return 0, 0, statErr
+		}
+		bytes += uint64(dirStat.GetLength())
+		inodes += uint64(dirStat.GetInodes())
+
+		// descend the directory skeleton only; files are counted by dir stats
+		entries, listErr := rpc.ListDentry(cmd, fsId, dir, epoch)
+		if listErr != nil {
+			return 0, 0, listErr
+		}
+		for _, d := range entries {
+			if d.GetType() == mds.FileType_DIRECTORY {
+				pending = append(pending, d.GetIno())
+			}
+		}
+	}
+
+	return bytes, inodes, nil
+}

--- a/cli/command/fs/updatefstrashdays.go
+++ b/cli/command/fs/updatefstrashdays.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 dingofs org, Inc. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs
+
+import (
+	"fmt"
+
+	"github.com/dingodb/dingocli/cli/cli"
+	"github.com/dingodb/dingocli/internal/common"
+	"github.com/dingodb/dingocli/internal/errno"
+	"github.com/dingodb/dingocli/internal/output"
+	"github.com/dingodb/dingocli/internal/rpc"
+	"github.com/dingodb/dingocli/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const (
+	FS_UPDATE_TRASH_DAYS_EXAMPLE = `Examples:
+# set trash retention to 7 days
+$ dingo fs updatefstrashdays --fsname dingofs1 --trashdays 7
+
+# disable the trash (0 empties the existing trash)
+$ dingo fs updatefstrashdays --fsname dingofs1 --trashdays 0`
+)
+
+type updateTrashDaysOptions struct {
+	fsname    string
+	trashdays uint32
+	format    string
+}
+
+func NewFsUpdateFsTrashDaysCommand(dingocli *cli.DingoCli) *cobra.Command {
+	var options updateTrashDaysOptions
+
+	cmd := &cobra.Command{
+		Use:     "updatefstrashdays [OPTIONS]",
+		Short:   "update the trash retention days of a filesystem (0 = disabled)",
+		Args:    utils.NoArgs,
+		Example: FS_UPDATE_TRASH_DAYS_EXAMPLE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			utils.ReadCommandConfig(cmd)
+			output.SetShow(utils.GetBoolFlag(cmd, utils.VERBOSE))
+
+			fsname, err := rpc.GetFsName(cmd)
+			if err != nil {
+				return err
+			}
+			options.fsname = fsname
+			options.trashdays = utils.GetUint32Flag(cmd, utils.DINGOFS_TRASH_DAYS)
+			options.format = utils.GetStringFlag(cmd, utils.FORMAT)
+
+			return runUpdateTrashDays(cmd, dingocli, options)
+		},
+		SilenceUsage:          false,
+		DisableFlagsInUseLine: true,
+	}
+
+	utils.SetFlagErrorFunc(cmd)
+
+	cmd.Flags().Uint32("fsid", 0, "Filesystem id")
+	cmd.Flags().String("fsname", "", "Filesystem name")
+	utils.AddUint32Flag(cmd, utils.DINGOFS_TRASH_DAYS, "Trash retention days, 0 = disabled")
+
+	utils.AddBoolFlag(cmd, utils.VERBOSE, "Show more debug info")
+	utils.AddConfigFileFlag(cmd)
+	utils.AddFormatFlag(cmd)
+
+	utils.AddDurationFlag(cmd, utils.RPCTIMEOUT, "RPC timeout")
+	utils.AddDurationFlag(cmd, utils.RPCRETRYDElAY, "RPC retry delay")
+	utils.AddUint32Flag(cmd, utils.RPCRETRYTIMES, "RPC retry times")
+
+	utils.AddStringFlag(cmd, utils.DINGOFS_MDSADDR, "Specify mds address")
+
+	return cmd
+}
+
+func runUpdateTrashDays(cmd *cobra.Command, dingocli *cli.DingoCli, options updateTrashDaysOptions) error {
+	outputResult := &common.OutputResult{
+		Error: errno.ERR_OK,
+	}
+
+	// read current fs info by name
+	fsInfo, err := rpc.GetFsInfo(cmd, 0, options.fsname)
+	if err != nil {
+		outputResult.Error = errno.ERR_RPC_FAILED.S(err.Error())
+		return outputErr(options.format, outputResult)
+	}
+	if fsInfo.GetFsId() == 0 {
+		outputResult.Error = errno.ERR_RPC_FAILED.S(fmt.Sprintf("not found fs %s", options.fsname))
+		return outputErr(options.format, outputResult)
+	}
+
+	// flip only trash_days and send the full FsInfo back
+	fsInfo.TrashDays = options.trashdays
+	if updErr := rpc.UpdateFsInfo(cmd, options.fsname, fsInfo); updErr != nil {
+		outputResult.Error = errno.ERR_RPC_FAILED.S(updErr.Error())
+		return outputErr(options.format, outputResult)
+	}
+
+	outputResult.Result = map[string]interface{}{
+		common.ROW_FS_NAME:       options.fsname,
+		utils.DINGOFS_TRASH_DAYS: options.trashdays,
+	}
+	if options.format == "json" {
+		return output.OutputJson(outputResult)
+	}
+
+	fmt.Printf("Successfully update filesystem %s trash_days to %d\n", options.fsname, options.trashdays)
+
+	return nil
+}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -168,4 +168,6 @@ type RpcOpions struct {
 // dingofs root inodeid
 const (
 	ROOTINODEID = uint64(1)
+	// trash root inode, mirrors kTrashInodeId in src/mds/common/trash.h
+	TRASHINODEID = uint64(0x7FFFFFFF00000003)
 )

--- a/internal/rpc/mds.go
+++ b/internal/rpc/mds.go
@@ -159,31 +159,45 @@ type ReadSliceRpc struct {
 	mdsClient mds.MDSServiceClient
 }
 
+type LookupRpc struct {
+	Info      *Rpc
+	Request   *mds.LookupRequest
+	mdsClient mds.MDSServiceClient
+}
+
+type RestoreFromTrashRpc struct {
+	Info      *Rpc
+	Request   *mds.RestoreFromTrashRequest
+	mdsClient mds.MDSServiceClient
+}
+
 // check interface
-var _ RpcFunc = (*GetMdsRpc)(nil)         // check interface
-var _ RpcFunc = (*CreateFsRpc)(nil)       // check interface
-var _ RpcFunc = (*DeleteFsRpc)(nil)       // check interface
-var _ RpcFunc = (*ListFsRpc)(nil)         // check interface
-var _ RpcFunc = (*GetFsRpc)(nil)          // check interface
-var _ RpcFunc = (*GetMdsRpc)(nil)         // check interface
-var _ RpcFunc = (*SetFsQuotaRpc)(nil)     // check interface
-var _ RpcFunc = (*GetFsQuotaRpc)(nil)     // check interface
-var _ RpcFunc = (*GetInodeRpc)(nil)       // check interface
-var _ RpcFunc = (*MkDirRpc)(nil)          // check interface
-var _ RpcFunc = (*GetDentryRpc)(nil)      // check interface
-var _ RpcFunc = (*ListDentryRpc)(nil)     // check interface
-var _ RpcFunc = (*GetFsStatsRpc)(nil)     // check interface
-var _ RpcFunc = (*UmountFsRpc)(nil)       // check interface
-var _ RpcFunc = (*SetDirQuotaRpc)(nil)    // check interface
-var _ RpcFunc = (*GetDirQuotaRpc)(nil)    // check interface
-var _ RpcFunc = (*ListDirQuotaRpc)(nil)   // check interface
-var _ RpcFunc = (*DeleteDirQuotaRpc)(nil) // check interface
-var _ RpcFunc = (*UnlinkFileRpc)(nil)     // check interface
-var _ RpcFunc = (*RmDirRpc)(nil)          // check interface
-var _ RpcFunc = (*GetDirStatRpc)(nil)     // check interface
-var _ RpcFunc = (*SyncDirStatRpc)(nil)    // check interface
-var _ RpcFunc = (*UpdateFsInfoRpc)(nil)   // check interface
-var _ RpcFunc = (*ReadSliceRpc)(nil)      // check interface
+var _ RpcFunc = (*GetMdsRpc)(nil)           // check interface
+var _ RpcFunc = (*CreateFsRpc)(nil)         // check interface
+var _ RpcFunc = (*DeleteFsRpc)(nil)         // check interface
+var _ RpcFunc = (*ListFsRpc)(nil)           // check interface
+var _ RpcFunc = (*GetFsRpc)(nil)            // check interface
+var _ RpcFunc = (*GetMdsRpc)(nil)           // check interface
+var _ RpcFunc = (*SetFsQuotaRpc)(nil)       // check interface
+var _ RpcFunc = (*GetFsQuotaRpc)(nil)       // check interface
+var _ RpcFunc = (*GetInodeRpc)(nil)         // check interface
+var _ RpcFunc = (*MkDirRpc)(nil)            // check interface
+var _ RpcFunc = (*GetDentryRpc)(nil)        // check interface
+var _ RpcFunc = (*ListDentryRpc)(nil)       // check interface
+var _ RpcFunc = (*GetFsStatsRpc)(nil)       // check interface
+var _ RpcFunc = (*UmountFsRpc)(nil)         // check interface
+var _ RpcFunc = (*SetDirQuotaRpc)(nil)      // check interface
+var _ RpcFunc = (*GetDirQuotaRpc)(nil)      // check interface
+var _ RpcFunc = (*ListDirQuotaRpc)(nil)     // check interface
+var _ RpcFunc = (*DeleteDirQuotaRpc)(nil)   // check interface
+var _ RpcFunc = (*UnlinkFileRpc)(nil)       // check interface
+var _ RpcFunc = (*RmDirRpc)(nil)            // check interface
+var _ RpcFunc = (*GetDirStatRpc)(nil)       // check interface
+var _ RpcFunc = (*SyncDirStatRpc)(nil)      // check interface
+var _ RpcFunc = (*UpdateFsInfoRpc)(nil)     // check interface
+var _ RpcFunc = (*ReadSliceRpc)(nil)        // check interface
+var _ RpcFunc = (*LookupRpc)(nil)           // check interface
+var _ RpcFunc = (*RestoreFromTrashRpc)(nil) // check interface
 
 func (mdsFs *GetMDSRpc) NewRpcClient(cc grpc.ClientConnInterface) {
 	mdsFs.mdsClient = mds.NewMDSServiceClient(cc)
@@ -432,5 +446,25 @@ func (readSlice *ReadSliceRpc) NewRpcClient(cc grpc.ClientConnInterface) {
 func (readSlice *ReadSliceRpc) Stub_Func(ctx context.Context) (interface{}, error) {
 	response, err := readSlice.mdsClient.ReadSlice(ctx, readSlice.Request)
 	output.ShowRpcData(readSlice.Request, response, readSlice.Info.RpcDataShow)
+	return response, err
+}
+
+func (lookup *LookupRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	lookup.mdsClient = mds.NewMDSServiceClient(cc)
+}
+
+func (lookup *LookupRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	response, err := lookup.mdsClient.Lookup(ctx, lookup.Request)
+	output.ShowRpcData(lookup.Request, response, lookup.Info.RpcDataShow)
+	return response, err
+}
+
+func (restoreFromTrash *RestoreFromTrashRpc) NewRpcClient(cc grpc.ClientConnInterface) {
+	restoreFromTrash.mdsClient = mds.NewMDSServiceClient(cc)
+}
+
+func (restoreFromTrash *RestoreFromTrashRpc) Stub_Func(ctx context.Context) (interface{}, error) {
+	response, err := restoreFromTrash.mdsClient.RestoreFromTrash(ctx, restoreFromTrash.Request)
+	output.ShowRpcData(restoreFromTrash.Request, response, restoreFromTrash.Info.RpcDataShow)
 	return response, err
 }

--- a/internal/rpc/operator.go
+++ b/internal/rpc/operator.go
@@ -672,6 +672,68 @@ func ReadSliceAll(cmd *cobra.Command, fsId uint32, inodeId uint64, parent uint64
 	return result.GetChunks(), nil
 }
 
+// Lookup resolves a child name under a parent inode to its inode. Routed by
+// the parent inode's owner.
+func Lookup(cmd *cobra.Command, fsId uint32, parent uint64, name string, epoch uint64) (*mds.Inode, error) {
+	endpoint := GetEndPoint(parent)
+	if len(endpoint) == 0 {
+		return nil, fmt.Errorf("endpoint is null")
+	}
+	mdsRpc := CreateNewMdsRpcWithEndPoint(cmd, endpoint, "Lookup")
+	lookupRpc := &LookupRpc{
+		Info: mdsRpc,
+		Request: &mds.LookupRequest{
+			Context: &mds.Context{Epoch: epoch},
+			FsId:    fsId,
+			Parent:  parent,
+			Name:    name,
+		},
+	}
+	response, rpcError := GetRpcResponse(lookupRpc.Info, lookupRpc)
+	if rpcError.GetCode() != errno.ERR_OK.GetCode() {
+		return nil, rpcError
+	}
+	result := response.(*mds.LookupResponse)
+	if mdsErr := result.GetError(); mdsErr.GetErrcode() != pbmdserror.Errno_OK {
+		return nil, errno.ERR_RPC_FAILED.S(mdsErr.String())
+	}
+
+	return result.GetInode(), nil
+}
+
+// RestoreFromTrash restores a single trash entry. The request is routed to the
+// mds owning origParent's partition so its caches are updated first-hand.
+func RestoreFromTrash(cmd *cobra.Command, fsId uint32, bucketIno uint64, trashName string, origParent uint64, allowTrashParent bool, carriedBytes uint64, carriedInodes uint64, epoch uint64) error {
+	endpoint := GetEndPoint(origParent)
+	if len(endpoint) == 0 {
+		return fmt.Errorf("no owner mds for parent(%d)", origParent)
+	}
+	mdsRpc := CreateNewMdsRpcWithEndPoint(cmd, endpoint, "RestoreFromTrash")
+	restoreRpc := &RestoreFromTrashRpc{
+		Info: mdsRpc,
+		Request: &mds.RestoreFromTrashRequest{
+			Context:          &mds.Context{Epoch: epoch},
+			FsId:             fsId,
+			TrashParent:      bucketIno,
+			TrashName:        trashName,
+			Uid:              0,
+			AllowTrashParent: allowTrashParent,
+			CarriedBytes:     carriedBytes,
+			CarriedInodes:    carriedInodes,
+		},
+	}
+	response, rpcError := GetRpcResponse(restoreRpc.Info, restoreRpc)
+	if rpcError.GetCode() != errno.ERR_OK.GetCode() {
+		return rpcError
+	}
+	result := response.(*mds.RestoreFromTrashResponse)
+	if mdsErr := result.GetError(); mdsErr.GetErrcode() != pbmdserror.Errno_OK {
+		return errno.ERR_RPC_FAILED.S(mdsErr.String())
+	}
+
+	return nil
+}
+
 // UpdateFsInfo sends a full FsInfo back to the mds (read-modify-write); the
 // server merges runtime-mutable fields. This is fs-level, not inode-scoped.
 func UpdateFsInfo(cmd *cobra.Command, fsName string, fsInfo *mds.FsInfo) error {

--- a/internal/utils/fs_config.go
+++ b/internal/utils/fs_config.go
@@ -125,6 +125,17 @@ const (
 	VIPER_DINGOFS_REPAIR      = "dingofs.repair"
 	DINGOFS_DEFAULT_REPAIR    = false
 
+	// restore trash
+	DINGOFS_HOURS                   = "hours"
+	VIPER_DINGOFS_HOURS             = "dingofs.hours"
+	DINGOFS_DEFAULT_HOURS           = ""
+	DINGOFS_PUT_BACK                = "putback"
+	VIPER_DINGOFS_PUT_BACK          = "dingofs.putback"
+	DINGOFS_DEFAULT_PUT_BACK        = false
+	DINGOFS_RESTORE_THREADS         = "restorethreads"
+	VIPER_DINGOFS_RESTORE_THREADS   = "dingofs.restorethreads"
+	DINGOFS_DEFAULT_RESTORE_THREADS = uint32(10)
+
 	DINGOFS_THREADS                = "threads"
 	VIPER_DINGOFS_THREADS          = "dingofs.threads"
 	DINGOFS_DEFAULT_THREADS        = uint32(8)
@@ -252,6 +263,11 @@ var (
 		DINGOFS_DEPTH:     VIPER_DINGOFS_DEPTH,
 		DINGOFS_ENTRIES:   VIPER_DINGOFS_ENTRIES,
 		DINGOFS_REPAIR:    VIPER_DINGOFS_REPAIR,
+
+		// restore trash
+		DINGOFS_HOURS:           VIPER_DINGOFS_HOURS,
+		DINGOFS_PUT_BACK:        VIPER_DINGOFS_PUT_BACK,
+		DINGOFS_RESTORE_THREADS: VIPER_DINGOFS_RESTORE_THREADS,
 	}
 	FLAG2DEFAULT = map[string]interface{}{
 		// rpc
@@ -309,6 +325,11 @@ var (
 		DINGOFS_DEPTH:     DINGOFS_DEFAULT_DEPTH,
 		DINGOFS_ENTRIES:   DINGOFS_DEFAULT_ENTRIES,
 		DINGOFS_REPAIR:    DINGOFS_DEFAULT_REPAIR,
+
+		// restore trash
+		DINGOFS_HOURS:           DINGOFS_DEFAULT_HOURS,
+		DINGOFS_PUT_BACK:        DINGOFS_DEFAULT_PUT_BACK,
+		DINGOFS_RESTORE_THREADS: DINGOFS_DEFAULT_RESTORE_THREADS,
 	}
 )
 

--- a/internal/utils/trash.go
+++ b/internal/utils/trash.go
@@ -1,0 +1,71 @@
+/*
+ * 	Copyright (c) 2026 dingofs org, Inc. All Rights Reserved
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package utils
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// trashBucketFormat is the UTC hour-bucket name layout "YYYY-MM-DD-HH".
+// Mirrors kBucketFormat in src/mds/common/trash.cc.
+const trashBucketFormat = "2006-01-02-15"
+
+// ParseTrashBucketName validates a trash hour-bucket name "YYYY-MM-DD-HH" (UTC)
+// and returns the unix timestamp in seconds. Returns 0 on failure.
+func ParseTrashBucketName(name string) uint64 {
+	t, err := time.ParseInLocation(trashBucketFormat, name, time.UTC)
+	if err != nil {
+		return 0
+	}
+	return uint64(t.Unix())
+}
+
+// ParseTrashEntryName parses a trash entry name "{parent_ino}-{file_ino}-{name}"
+// into its components. Mirrors ParseTrashEntryName in src/mds/common/trash.cc.
+func ParseTrashEntryName(trashName string) (parentIno uint64, fileIno uint64, originalName string, ok bool) {
+	pos1 := strings.IndexByte(trashName, '-')
+	if pos1 < 0 {
+		return 0, 0, "", false
+	}
+	pos2 := strings.IndexByte(trashName[pos1+1:], '-')
+	if pos2 < 0 {
+		return 0, 0, "", false
+	}
+	pos2 += pos1 + 1
+
+	p, err := strconv.ParseUint(trashName[:pos1], 10, 64)
+	if err != nil {
+		return 0, 0, "", false
+	}
+	f, err := strconv.ParseUint(trashName[pos1+1:pos2], 10, 64)
+	if err != nil {
+		return 0, 0, "", false
+	}
+
+	return p, f, trashName[pos2+1:], true
+}
+
+// ParseTrashEntryParent returns just the original parent inode from a trash
+// entry name, or 0 if it cannot be parsed.
+func ParseTrashEntryParent(trashName string) uint64 {
+	parent, _, _, ok := ParseTrashEntryName(trashName)
+	if !ok {
+		return 0
+	}
+	return parent
+}


### PR DESCRIPTION
- Added new `dingo fs restoretrash` subcommand to restore items from the file system's trash.
- Added new `dingo fs updatefstrashdays` subcommand to dynamically update the trash retention days for a file system.